### PR TITLE
Improve README style and add docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,66 @@
-# StarDust - KI-Assistent für schnelle Antworten
+# ✨ StarDust
 
-StarDust ist ein leistungsstarker KI-Assistent, der direkt in Ihrem System läuft und Ihnen hilft, schnell Antworten auf Ihre Fragen zu bekommen. Mit einem einfachen Hotkey können Sie den Assistenten aktivieren und Ihre Fragen stellen.
+**KI-Assistent für schnelle Antworten direkt unter Windows**
+
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
+StarDust läuft lokal auf Ihrem Rechner und liefert per Hotkey blitzschnell Antworten über die OpenAI-API.
+
+## Inhalt
+
+- [Features](#features)
+- [Installation](#installation)
+- [Verwendung](#verwendung)
+- [Entwicklung](#entwicklung)
+- [Mitwirken](#mitwirken)
+- [Sicherheit](#sicherheit)
 
 ## Features
 
-- 🚀 Schnelle Antworten durch OpenAI GPT-3.5
-- ⌨️ Einfache Aktivierung mit Hotkey (Ctrl+Alt+Y)
-- 📝 Automatische Texterkennung
-- 💻 System-Tray-Integration
-- 🔒 Lokale API-Key-Speicherung
-- 📊 Detailliertes Logging
+- 🚀 **Schnelle Antworten** durch OpenAI GPT-3.5
+- ⌨️ **Einfacher Start** via `Ctrl+Alt+Y`
+- 📝 **Texterkennung** aus der Zwischenablage
+- 💻 **System-Tray-Icon** für schnellen Zugriff
+- 🔒 **Lokale API-Key-Speicherung**
+- 📊 **Umfangreiches Logging**
 
 ## Installation
 
-1. Laden Sie die neueste Version von StarDust aus dem [Releases](https://github.com/yourusername/StarDust/releases) Bereich herunter
-2. Führen Sie die `StarDust.exe` aus
-3. Bei der ersten Ausführung werden Sie nach Ihrem OpenAI API-Key gefragt
+1. Neueste Version im [Release-Bereich](https://github.com/yourusername/StarDust/releases) herunterladen
+2. `StarDust.exe` starten
+3. Beim ersten Start nach dem OpenAI-API-Key fragen lassen
 
 ## Verwendung
 
-1. Drücken Sie `Ctrl+Alt+Y` um den Aufnahmemodus zu starten
-2. Geben Sie Ihre Frage ein
-3. Drücken Sie `Ctrl+Alt+X` um die Aufnahme zu beenden
-4. Die Antwort wird automatisch in die Zwischenablage kopiert
-5. Sie haben zwei Möglichkeiten, die Antwort einzufügen:
-   - **Mit `Ctrl+V`**: Die komplette Antwort wird sofort eingefügt (Paste)
-   - **Mit `Ctrl+Alt+V`**: Die Antwort wird Zeichen für Zeichen wie getippt eingefügt (z.B. für Programme, die kein direktes Einfügen erlauben)
+1. `Ctrl+Alt+Y` – Aufnahmemodus starten
+2. Frage eingeben
+3. `Ctrl+Alt+X` – Aufnahme beenden
+4. Antwort landet in der Zwischenablage
+5. Zwei Arten der Ausgabe:
+   - **`Ctrl+V`** fügt alles direkt ein
+   - **`Ctrl+Alt+V`** tippt die Antwort Zeichen für Zeichen
 
 ### Hotkeys
 
-- `Ctrl+Alt+Y`: Aufnahmemodus starten
-- `Ctrl+Alt+X`: Aufnahmemodus beenden
-- `Ctrl+Alt+V`: Antwort einfügen
-- `Win+Esc`: Aktuellen Modus abbrechen
+- `Ctrl+Alt+Y` – Start Aufnahme
+- `Ctrl+Alt+X` – Ende Aufnahme
+- `Ctrl+Alt+V` – Antwort einfügen
+- `Win+Esc` – aktuellen Modus abbrechen
 
 ## Entwicklung
 
 ### Voraussetzungen
 
-- Python 3.12 oder höher
+- Python ≥ 3.12
 - OpenAI API-Key
 
-### Installation der Abhängigkeiten
+### Abhängigkeiten installieren
 
 ```bash
 pip install -r requirements.txt
 ```
 
-### Erstellen der EXE-Datei
+### EXE-Datei erstellen
 
 ```bash
 pyinstaller StarDust.spec
@@ -55,14 +68,14 @@ pyinstaller StarDust.spec
 
 ## Lizenz
 
-Dieses Projekt ist unter der MIT-Lizenz lizenziert - siehe die [LICENSE](LICENSE) Datei für Details.
+Dieses Projekt steht unter der [MIT-Lizenz](LICENSE).
 
 ## Mitwirken
 
-Beiträge sind willkommen! Bitte erstellen Sie einen Pull Request oder öffnen Sie ein Issue für Verbesserungsvorschläge.
+Pull Requests und Issues sind jederzeit willkommen!
 
 ## Sicherheit
 
-- Der API-Key wird lokal in der AppData gespeichert
-- Keine Daten werden an Dritte gesendet
-- Alle Kommunikation erfolgt direkt mit der OpenAI API 
+- API-Key wird nur lokal gespeichert
+- Keine Datenweitergabe an Dritte
+- Kommunikation ausschließlich mit der OpenAI-API

--- a/StarDust.py
+++ b/StarDust.py
@@ -1,3 +1,10 @@
+"""StarDust Hauptprogramm.
+
+Dieser kleine Helfer lauscht auf Hotkeys, sendet eingegebene Fragen an die
+OpenAI‑API und kopiert die Antwort direkt in die Zwischenablage. Die Datei
+enthält das komplette Tray‑ und Hotkey‑Handling.
+"""
+
 import keyboard
 import pyperclip
 import openai
@@ -73,6 +80,16 @@ last_response = ""
 current_write_index = 0
 
 def get_ai_response(prompt, context=None, use_context=False):
+    """Sende die Eingabe an die OpenAI-API und liefere die Antwort zurück.
+
+    Args:
+        prompt: Die Benutzerfrage.
+        context: Optionaler Kontext aus der Zwischenablage.
+        use_context: Wenn True wird der Kontext dem Prompt hinzugefügt.
+
+    Returns:
+        String mit der Antwort der KI oder einer Fehlermeldung.
+    """
     try:
         # Prüfe ob es eine mathematische Berechnung ist
         if any(op in prompt for op in ['+', '-', '*', '/']):
@@ -120,6 +137,7 @@ def get_ai_response(prompt, context=None, use_context=False):
         return "Fehler bei der API-Anfrage"
 
 def set_cursor_style(style):
+    """Ändert das Aussehen des Mauszeigers je nach Programmzustand."""
     try:
         if style == "recording":
             # Roter Cursor
@@ -135,6 +153,7 @@ def set_cursor_style(style):
         logging.error(f"Fehler beim Ändern des Cursors: {str(e)}")
 
 def on_key_event(event):
+    """Verarbeitet Tastatureingaben während des Programms."""
     global is_listening, is_writing, current_text, current_write_index, last_response
     if event.event_type == keyboard.KEY_DOWN:
         if is_writing:
@@ -163,6 +182,7 @@ def on_key_event(event):
             logging.info(f"Text aktualisiert: {current_text}")
 
 def start_listening():
+    """Startet den Aufnahmemodus für Benutzereingaben."""
     global is_listening, current_text
     is_listening = True
     current_text = ""
@@ -170,6 +190,7 @@ def start_listening():
     logging.info("=== Aufnahmemodus gestartet ===")
 
 def stop_listening():
+    """Beendet den Aufnahmemodus und schickt die Anfrage an die KI."""
     global is_listening, last_response
     if is_listening:
         is_listening = False
@@ -190,6 +211,7 @@ def stop_listening():
             logging.info(f"Antwort: {response[:50]}...")
 
 def toggle_write_mode():
+    """Schaltet den Schreibmodus zum automatischen Tippen um."""
     global is_writing, current_write_index
     if not is_writing and last_response:
         is_writing = True
@@ -202,6 +224,7 @@ def toggle_write_mode():
         logging.info("=== Write Mode beendet ===")
 
 def cancel_listening():
+    """Bricht Aufnahme- oder Schreibmodus sofort ab."""
     global is_listening, is_writing
     if is_listening or is_writing:
         is_listening = False
@@ -210,6 +233,7 @@ def cancel_listening():
         logging.info("=== Modus abgebrochen ===")
 
 def create_tray_icon():
+    """Erzeugt das System-Tray-Icon mit Beenden-Menü."""
     def on_exit(icon, item):
         icon.stop()
         os._exit(0)
@@ -224,6 +248,7 @@ def create_tray_icon():
     icon.run_detached()
 
 def main():
+    """Initialisiert Hotkeys und startet die Ereignisschleife."""
     create_tray_icon()
     try:
         # Registriere die Hotkeys
@@ -242,4 +267,4 @@ def main():
         set_cursor_style("normal")
 
 if __name__ == "__main__":
-    main() 
+    main()


### PR DESCRIPTION
## Summary
- restyle README with a clearer layout
- document Python functions with docstrings for easier understanding

## Testing
- `python -m py_compile StarDust.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68429402ad988331b4d6f0b011fb5218